### PR TITLE
feat(core): 增加消费者线程池配置实现多线程任务消费

### DIFF
--- a/xxl-mq-core/src/main/java/com/xxl/mq/core/bootstrap/XxlMqBootstrap.java
+++ b/xxl-mq-core/src/main/java/com/xxl/mq/core/bootstrap/XxlMqBootstrap.java
@@ -114,6 +114,24 @@ public class XxlMqBootstrap {
     private RegistryThread registryThread = null;
 
     private PullThread pullThread = null;
+    private int consumerThreadPoolSize = 1;
+    private int consumerThreadPoolMaxSize = 1;
+
+    public int getConsumerThreadPoolSize() {
+        return consumerThreadPoolSize;
+    }
+
+    public void setConsumerThreadPoolSize(int consumerThreadPoolSize) {
+        this.consumerThreadPoolSize = consumerThreadPoolSize;
+    }
+
+    public int getConsumerThreadPoolMaxSize() {
+        return consumerThreadPoolMaxSize;
+    }
+
+    public void setConsumerThreadPoolMaxSize(int consumerThreadPoolMaxSize) {
+        this.consumerThreadPoolMaxSize = consumerThreadPoolMaxSize;
+    }
 
     public String getInstanceUuid() {
         return instanceUuid;

--- a/xxl-mq-core/src/main/java/com/xxl/mq/core/thread/ConsumerThread.java
+++ b/xxl-mq-core/src/main/java/com/xxl/mq/core/thread/ConsumerThread.java
@@ -32,7 +32,8 @@ public class ConsumerThread {
     public ConsumerThread(XxlMqBootstrap xxlMqBootstrap, IConsumer consumer) {
         this.xxlMqBootstrap = xxlMqBootstrap;
         this.consumer = consumer;
-        this.scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+        this.scheduledExecutorService = new ScheduledThreadPoolExecutor(xxlMqBootstrap.getConsumerThreadPoolSize());
+        this.scheduledExecutorService.setMaximumPoolSize(xxlMqBootstrap.getConsumerThreadPoolMaxSize());
         this.lastExecuteTime = System.currentTimeMillis();
     }
 

--- a/xxl-mq-samples/xxl-mq-samples-springboot/src/main/java/com/xxl/mq/sample/springboot/conf/XxlMqConfig.java
+++ b/xxl-mq-samples/xxl-mq-samples-springboot/src/main/java/com/xxl/mq/sample/springboot/conf/XxlMqConfig.java
@@ -25,10 +25,13 @@ public class XxlMqConfig {
     private int batchsize;
     @Value("${xxl.mq.client.consumer.pull.interval}")
     private int interval;
-
+    @Value("${xxl.mq.client.consumer.threadPoolSize}")
+    private int consumerThreadPoolSize;
+    @Value("${xxl.mq.client.consumer.threadPoolMaxSize}")
+    private int consumerThreadPoolMaxSize;
 
     @Bean
-    public XxlMqSpringBootstrap getXxlMqConsumer(){
+    public XxlMqSpringBootstrap getXxlMqConsumer() {
         // init xxl-mq spring bootstrap
         XxlMqSpringBootstrap xxlMqBootstrap = new XxlMqSpringBootstrap();
         xxlMqBootstrap.setAddress(address);
@@ -38,7 +41,8 @@ public class XxlMqConfig {
         xxlMqBootstrap.setConsumerEnabled(consumerEnabled);
         xxlMqBootstrap.setPullBatchsize(batchsize);
         xxlMqBootstrap.setPullInterval(interval);
-
+        xxlMqBootstrap.setConsumerThreadPoolSize(consumerThreadPoolSize);
+        xxlMqBootstrap.setConsumerThreadPoolMaxSize(consumerThreadPoolMaxSize);
         return xxlMqBootstrap;
     }
 

--- a/xxl-mq-samples/xxl-mq-samples-springboot/src/main/resources/application.properties
+++ b/xxl-mq-samples/xxl-mq-samples-springboot/src/main/resources/application.properties
@@ -30,4 +30,8 @@ xxl.mq.client.consumer.enabled=true
 xxl.mq.client.consumer.pull.batchsize=100
 ## xxl-mq, client consumer pull interval
 xxl.mq.client.consumer.pull.interval=1000
+## xxl-mq, client consumer thread pool size
+xxl.mq.client.consumer.threadPoolSize=10
+## xxl-mq, client consumer thread pool max size
+xxl.mq.client.consumer.threadPoolMaxSize=20
 


### PR DESCRIPTION
- 在 XxlMqBootstrap 类中添加消费者线程池大小和最大线程池大小属性
- 修改 ConsumerThread 类，使用配置的线程池大小初始化 ScheduledThreadPoolExecutor
- 在示例项目中添加消费者线程池配置属性
- 更新 application.properties 文件，增加消费者线程池大小和最大线程池大小配置项