### PR TITLE
修订示例连接，补充集群连接示例

### DIFF
--- a/xxl-mq-samples/xxl-mq-samples-frameless/src/main/resources/xxl-mq.properties
+++ b/xxl-mq-samples/xxl-mq-samples-frameless/src/main/resources/xxl-mq.properties
@@ -1,4 +1,4 @@
-## xxl-mq, admin address
+### xxl-mq admin address list, such as "http://address" or "http://address01,http://address02"
 xxl.mq.admin.address=http://127.0.0.1:8080/xxl-mq-admin
 ## xxl-mq, admin accesstoken
 xxl.mq.admin.accesstoken=defaultaccesstoken

--- a/xxl-mq-samples/xxl-mq-samples-springboot/src/main/resources/application.properties
+++ b/xxl-mq-samples/xxl-mq-samples-springboot/src/main/resources/application.properties
@@ -16,7 +16,7 @@ spring.freemarker.settings.number_format=0.##########
 spring.freemarker.settings.new_builtin_class_resolver=safer
 
 
-## xxl-mq, admin address
+### xxl-mq admin address list, such as "http://address" or "http://address01,http://address02"
 xxl.mq.admin.address=http://127.0.0.1:8080/xxl-mq-admin
 ## xxl-mq, admin accesstoken
 xxl.mq.admin.accesstoken=defaultaccesstoken


### PR DESCRIPTION
修订示例连接，补充集群连接示例
xxl-mq admin address list, such as "[http://address](https://gitee.com/link?target=http%3A%2F%2Faddress)" or "[http://address01](https://gitee.com/link?target=http%3A%2F%2Faddress01),[http://address02](https://gitee.com/link?target=http%3A%2F%2Faddress02)"
xxl.mq.admin.address=[http://127.0.0.1:8080/xxl-mq-admin](https://gitee.com/link?target=http%3A%2F%2F127.0.0.1%3A8080%2Fxxl-mq-admin)